### PR TITLE
throw on reading undefined file path

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,10 @@ module.exports = function (file, opts) {
   return sm;
 
   function readFile(file, enc, cb) {
+    if (file === undefined) {
+      throw new Error('file is not resolvable');
+    }
+    
     if (typeof enc === "function") {
       cb = enc;
       enc = null;
@@ -93,6 +97,10 @@ module.exports = function (file, opts) {
   }
 
   function readFileSync(file, enc) {
+    if (file === undefined) {
+      throw new Error('file is not resolvable');
+    }
+    
     var isBuffer = false;
     if (enc === null || enc === undefined) {
       isBuffer = true;


### PR DESCRIPTION
Fixes building lighthouse in Node 15.

`static-module` calls brfs when it encounters a `fs.readFileSync` (and the other read methods) with a string `file` if the path can be statically determined or `undefined` if the path is too dynamic to figure out.

Previous to Node 15, when brfs then does `fs.createReadStream(file)`, if `file` is `undefined` it would immediately throw, `static-module` would [catch the error](https://github.com/browserify/static-module/blob/d70e12cb889f93a9a5935dcf1e201f609e99538a/index.js#L340-L344), and the original code would be retained instead of replacing it with an inline string.

Node 15 made a change to stream construction (https://github.com/nodejs/node/pull/29656) that made stream construction lazier, and so the error comes later (when piping begins), `static-module` no longer catches the error, and everything fails instead of continuing.

This is probably the simplest fix, still throwing if `file` is undefined, just explicitly now instead of relying on `fs.createReadStream` throwing.